### PR TITLE
クロスオリジンの検証を無効化

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,9 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # 勉強用のためクロスオリジンの検証を無効にする
+  config.action_controller.forgery_protection_origin_check = false
+  
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 


### PR DESCRIPTION
登録が失敗する原因がわかりました。
リクエストされるURLのチェックで、個人開発（localhost）だと問題ないけど、Codespaesのような公開されているようなサイトではセキュリティを考える必要があり、その部分が抜けていたために登録が失敗していました。
このPRでチェックを無効化しています。

詳しくは↓を見ていただくとわかるかも。。。。

https://qiita.com/munaita_/items/e1d36fac9515654a76de
https://midorimici.com/posts/rails-api-csrf